### PR TITLE
Feature/#73 support index within

### DIFF
--- a/api/src/main/java/com/rbmhtechnology/vind/api/CompletableSearchServer.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/CompletableSearchServer.java
@@ -228,6 +228,16 @@ public class CompletableSearchServer extends SearchServer {
     }
 
     @Override
+    public IndexResult indexWithin(Document doc, int withinMs) {
+        return backend.indexWithin(doc, withinMs);
+    }
+
+    @Override
+    public IndexResult indexWithin(List<Document> doc, int withinMs) {
+        return backend.indexWithin(doc, withinMs);
+    }
+
+    @Override
     public boolean execute(Update update, DocumentFactory factory) {
         return backend.execute(update, factory);
     }
@@ -240,6 +250,11 @@ public class CompletableSearchServer extends SearchServer {
     @Override
     public DeleteResult delete(Document doc) {
         return backend.delete(doc);
+    }
+
+    @Override
+    public DeleteResult deleteWithin(Document doc, int withinMs) {
+        return backend.deleteWithin(doc, withinMs);
     }
 
     @Override

--- a/api/src/main/java/com/rbmhtechnology/vind/api/SearchServer.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/SearchServer.java
@@ -190,6 +190,22 @@ public abstract class SearchServer implements Closeable {
     public abstract IndexResult index(List<Document> doc);
 
     /**
+     * Adds a {@link Document} to the search server index. {@link SearchServer#commit()} should be executed afterwards for
+     * this change to take place on the index.
+     * @param doc comma separated {@link Document}s to be indexed.
+     * @param withinMs documents are visible in search within ms
+     */
+    public abstract IndexResult indexWithin(Document doc, int withinMs);
+
+    /**
+     * Adds a {@link Document} or {@link Document}s to the search server index. {@link SearchServer#commit()} should be executed afterwards for
+     * this change to take place on the  index.
+     * @param doc comma separated {@link Document}s to be indexed.
+     * @param withinMs documents are visible in search within ms
+     */
+    public abstract IndexResult indexWithin(List<Document> doc, int withinMs);
+
+    /**
      * Removes a {@link Document} from the search server index. {@link SearchServer#commit()} should be executed afterwards for
      * this change to take place on the  index.
      * @param doc {@link Document} to be indexed.
@@ -197,6 +213,16 @@ public abstract class SearchServer implements Closeable {
      * @throws SearchServerException if not possible to perform the deletion.
      */
     public abstract DeleteResult delete(Document doc);
+
+    /**
+     * Removes a {@link Document} from the search server index. {@link SearchServer#commit()} should be executed afterwards for
+     * this change to take place on the  index.
+     * @param doc {@link Document} to be indexed.
+     * @param withinMs documents are visible in search within ms
+     * @return {@link DeleteResult} instance containing the deletion execution info.
+     * @throws SearchServerException if not possible to perform the deletion.
+     */
+    public abstract DeleteResult deleteWithin(Document doc, int withinMs);
 
     /**
      *  Changes a document in the index, based on the modifications described by {@link Update}.

--- a/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
+++ b/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
@@ -162,7 +162,7 @@ public class SolrSearchServer extends SearchServer {
     public IndexResult index(Document ... docs) {
         Asserts.notNull(docs,"Document to index should not be null.");
         Asserts.check(docs.length > 0, "Should be at least one document to index.");
-        return indexMultipleDocuments(Arrays.asList(docs));
+        return indexMultipleDocuments(Arrays.asList(docs), -1);
     }
 
     @Override
@@ -170,10 +170,20 @@ public class SolrSearchServer extends SearchServer {
         Asserts.notNull(docs,"Document to index should not be null.");
         Asserts.check(docs.size() > 0, "Should be at least one document to index.");
 
-        return  indexMultipleDocuments(docs);
+        return  indexMultipleDocuments(docs, -1);
     }
 
-    private IndexResult indexSingleDocument(Document doc) {
+    @Override
+    public IndexResult indexWithin(Document doc, int withinMs) {
+        return this.indexSingleDocument(doc, withinMs);
+    }
+
+    @Override
+    public IndexResult indexWithin(List<Document> doc, int withinMs) {
+        return this.indexMultipleDocuments(doc, withinMs);
+    }
+
+    private IndexResult indexSingleDocument(Document doc, int withinMs) {
         final SolrInputDocument document = createInputDocument(doc);
         try {
             if (solrClientLogger.isTraceEnabled()) {
@@ -182,8 +192,8 @@ public class SolrSearchServer extends SearchServer {
                 solrClientLogger.debug(">>> add({})", doc.getId());
             }
 
-            removeNonParentDocument(doc);
-            final UpdateResponse response = this.solrClient.add(document);
+            removeNonParentDocument(doc, withinMs);
+            final UpdateResponse response = withinMs < 0 ? this.solrClient.add(document) : this.solrClient.add(document, withinMs);
             return new IndexResult(Long.valueOf(response.getQTime())).setElapsedTime(response.getElapsedTime());
 
         } catch (SolrServerException | IOException e) {
@@ -192,7 +202,7 @@ public class SolrSearchServer extends SearchServer {
         }
     }
 
-    private IndexResult indexMultipleDocuments(List<Document> docs) {
+    private IndexResult indexMultipleDocuments(List<Document> docs, int withinMs) {
         final List<SolrInputDocument> solrDocs = docs.parallelStream()
                 .map(doc -> createInputDocument(doc))
                 .collect(Collectors.toList());
@@ -203,10 +213,10 @@ public class SolrSearchServer extends SearchServer {
                 solrClientLogger.debug(">>> add({})", solrDocs);
             }
             for(Document doc : docs){
-                removeNonParentDocument(doc);
+                removeNonParentDocument(doc, withinMs);
             }
 
-            final UpdateResponse response = this.solrClient.add(solrDocs);
+            final UpdateResponse response = withinMs < 0 ? this.solrClient.add(solrDocs) : this.solrClient.add(solrDocs, withinMs);
             return new IndexResult(Long.valueOf(response.getQTime())).setElapsedTime(response.getElapsedTime());
 
         } catch (SolrServerException | IOException e) {
@@ -215,7 +225,7 @@ public class SolrSearchServer extends SearchServer {
         }
     }
 
-    private void removeNonParentDocument(Document doc) throws SolrServerException, IOException {
+    private void removeNonParentDocument(Document doc, int withinMs) throws SolrServerException, IOException {
         if(CollectionUtils.isNotEmpty(doc.getChildren())) {
             //Get the nested docs of the document if existing
             final NamedList<Object> paramList = new NamedList<>();
@@ -223,7 +233,12 @@ public class SolrSearchServer extends SearchServer {
             final QueryResponse query = solrClient.query(SolrParams.toSolrParams(paramList), SolrRequest.METHOD.POST);
             if (CollectionUtils.isEmpty(query.getResults()))
                 log.info("Deleting document `{}`: document is becoming parent.",doc.getId());
+
+            if(withinMs < 0) {
                 this.solrClient.deleteById(doc.getId());
+            } else {
+                this.solrClient.deleteById(doc.getId(), withinMs);
+            }
         }
     }
 
@@ -317,15 +332,20 @@ public class SolrSearchServer extends SearchServer {
 
     @Override
     public DeleteResult delete(Document doc) {
+        return this.deleteWithin(doc, -1);
+    }
+
+    @Override
+    public DeleteResult deleteWithin(Document doc, int withinMs) {
         try {
             long qTime = 0;
             long elapsedTime = 0;
             solrClientLogger.debug(">>> delete({})", doc.getId());
-            final UpdateResponse deleteResponse = solrClient.deleteById(doc.getId());
+            final UpdateResponse deleteResponse = withinMs < 0 ? solrClient.deleteById(doc.getId()) : solrClient.deleteById(doc.getId(), withinMs);
             qTime = deleteResponse.getQTime();
             elapsedTime = deleteResponse.getElapsedTime();
             //Deleting nested documents
-            final UpdateResponse deleteNestedResponse = solrClient.deleteByQuery("_root_:" + doc.getId());
+            final UpdateResponse deleteNestedResponse = withinMs < 0 ? solrClient.deleteByQuery("_root_:" + doc.getId()) : solrClient.deleteByQuery("_root_:" + doc.getId(), withinMs);
             qTime += deleteNestedResponse.getQTime();
             elapsedTime += deleteNestedResponse.getElapsedTime();
 

--- a/docs/dynamic_fields.md
+++ b/docs/dynamic_fields.md
@@ -47,3 +47,22 @@ public SearchService() {
             .build();
 }
 ```
+
+### 4.2 Indexing dynamic documents
+
+As simple pojos, dynamic documents can be added to the index and made visible by a commit.
+
+````java
+server.index(item);
+server.commit();
+````
+Additionally to that (as hard commit is a quite time consuming operation and not always necessary), we added a 
+function that allows to index a document and guarantee, that is available by search within a certain ammount of milliseconds.
+Note, a hard commit is then not necessary (even if it is neccessary to persist the index to disc, you don't have to take care, it's been done automatically every 60 seconds).
+So, adding a document like this:
+
+````java
+server.index(item, 2000);
+````
+
+guarantees, that the item can be found within 2 seconds.

--- a/monitoring/monitoring-api/src/main/java/com/rbmhtechnology/vind/monitoring/MonitoringSearchServer.java
+++ b/monitoring/monitoring-api/src/main/java/com/rbmhtechnology/vind/monitoring/MonitoringSearchServer.java
@@ -106,6 +106,16 @@ public class MonitoringSearchServer extends SearchServer {
         return index(docs,this.session);
     }
 
+    @Override
+    public IndexResult indexWithin(Document doc, int withinMs) {
+        return server.indexWithin(doc, withinMs);
+    }
+
+    @Override
+    public IndexResult indexWithin(List<Document> doc, int withinMs) {
+        return server.indexWithin(doc, withinMs);
+    }
+
     public IndexResult index(List<Document> docs, Session session) {
         final ZonedDateTime start = ZonedDateTime.now();
         log.debug("Monitoring server is indexing document'{}' at {}:{}:{} - {}.{}.{} ", docs.stream().map(Document::getId).collect(Collectors.toList()),
@@ -173,6 +183,11 @@ public class MonitoringSearchServer extends SearchServer {
     @Override
     public DeleteResult delete(Document doc) {
         return delete(doc,this.session);
+    }
+
+    @Override
+    public DeleteResult deleteWithin(Document doc, int withinMs) {
+        return server.deleteWithin(doc, withinMs);
     }
 
     public DeleteResult delete(Document doc, Session session) {

--- a/test/src/test/java/com/rbmhtechnology/vind/test/CommitTest.java
+++ b/test/src/test/java/com/rbmhtechnology/vind/test/CommitTest.java
@@ -1,0 +1,29 @@
+package com.rbmhtechnology.vind.test;
+
+import com.rbmhtechnology.vind.api.query.Search;
+import com.rbmhtechnology.vind.model.DocumentFactory;
+import com.rbmhtechnology.vind.model.DocumentFactoryBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CommitTest {
+
+    @Rule
+    public TestSearchServer testSearchServer = new TestSearchServer();
+
+    private DocumentFactory document = new DocumentFactoryBuilder("document").build();
+
+    @Test
+    public void testDocumentCommitWithin() throws InterruptedException {
+        testSearchServer.getSearchServer().indexWithin(document.createDoc("1"), 1000);
+
+        Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.getById("1"), document).getNumOfResults());
+        Assert.assertEquals(0, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
+        Thread.sleep(1100);
+
+        Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+    }
+
+}

--- a/test/src/test/java/com/rbmhtechnology/vind/test/CommitTest.java
+++ b/test/src/test/java/com/rbmhtechnology/vind/test/CommitTest.java
@@ -1,5 +1,7 @@
 package com.rbmhtechnology.vind.test;
 
+import com.google.common.collect.ImmutableList;
+import com.rbmhtechnology.vind.api.Document;
 import com.rbmhtechnology.vind.api.query.Search;
 import com.rbmhtechnology.vind.model.DocumentFactory;
 import com.rbmhtechnology.vind.model.DocumentFactoryBuilder;
@@ -24,6 +26,44 @@ public class CommitTest {
         Thread.sleep(1100);
 
         Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
+        testSearchServer.getSearchServer().clearIndex();
+    }
+
+    @Test
+    public void testMultipleDocumentsCommitWithin() throws InterruptedException {
+        testSearchServer.getSearchServer().indexWithin(ImmutableList.of(
+               document.createDoc("2"),
+               document.createDoc("3")
+        ),1000);
+
+        Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.getById("2"), document).getNumOfResults());
+        Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.getById("3"), document).getNumOfResults());
+        Assert.assertEquals(0, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
+        Thread.sleep(1100);
+
+        Assert.assertEquals(2, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
+        testSearchServer.getSearchServer().clearIndex();
+    }
+
+    @Test
+    public void testRemoveDocumentWithin() throws InterruptedException {
+        Document doc = document.createDoc("4");
+
+        testSearchServer.getSearchServer().index(doc);
+        testSearchServer.getSearchServer().commit();
+
+        testSearchServer.getSearchServer().deleteWithin(doc, 1000);
+
+        Assert.assertEquals(0, testSearchServer.getSearchServer().execute(Search.getById("4"), document).getNumOfResults());
+        Assert.assertEquals(1, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
+        Thread.sleep(1100);
+
+        Assert.assertEquals(0, testSearchServer.getSearchServer().execute(Search.fulltext(), document).getNumOfResults());
+
     }
 
 }


### PR DESCRIPTION
Currently these methods are supported:
```
indexWithin(Document doc, int indexWithin);
indexWithin(List<Document> doc, int indexWithin)
deleteWithin(Document doc, int indexWithin)
```
The functionality is tested and documented.