### PR TITLE
Fix url creation for Windows systems

### DIFF
--- a/backend/solr-ext/collection-managment-tool/src/main/java/com/rbmhtechnology/vind/solr/cmt/CollectionManagementService.java
+++ b/backend/solr-ext/collection-managment-tool/src/main/java/com/rbmhtechnology/vind/solr/cmt/CollectionManagementService.java
@@ -52,7 +52,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-;
 
 /**
  * @author Thomas Kurz (thomas.kurz@redlink.co)
@@ -583,7 +582,7 @@ public class CollectionManagementService {
             for(String repository : repositories)
                 try {
                     if (repository.matches("https?://.*")) {
-                        final URI uri = new URI((repository.endsWith("/") ? repository : (repository + "/")) + nameToPath(name));
+                        final URI uri = new URI((repository.endsWith("/") ? repository : (repository + "/")) + nameToUrlPath(name));
                         try {
                             return httpClient.execute(new HttpGet(uri), new DownloadResponseHandler(uri, directory));
                         } catch (IOException e) {
@@ -644,7 +643,17 @@ public class CollectionManagementService {
             return Paths.get(split[0].replaceAll("\\.","/"),split[1],split[2],split[1]+"-"+split[2]+".jar").toFile().getPath();
         }
 
-        public static String nameToMetadataPath(String name) throws IOException {
+        public static String nameToUrlPath(String name) throws IOException {
+            String[] split = name.split(":");
+
+            if (split.length != 3) {
+                throw new IOException("Cannot get download path for " + name);
+            }
+
+            return String.join("/",split[0].replaceAll("\\.","/"),split[1],split[2],split[1]+"-"+split[2]+".jar");
+        }
+
+      public static String nameToMetadataPath(String name) throws IOException {
             String[] split = name.split(":");
 
             if(split.length != 3) throw new IOException("Cannot get dowload path for " + name);

--- a/backend/solr-ext/collection-managment-tool/src/test/java/com/rbmhtechnology/vind/solr/cmt/CollectionManagementServiceUtilsTest.java
+++ b/backend/solr-ext/collection-managment-tool/src/test/java/com/rbmhtechnology/vind/solr/cmt/CollectionManagementServiceUtilsTest.java
@@ -1,7 +1,6 @@
 package com.rbmhtechnology.vind.solr.cmt;
 
 import com.google.common.io.Resources;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -36,7 +35,13 @@ public class CollectionManagementServiceUtilsTest {
     @Test
     public void utilsNameToPathTest() throws IOException {
         String path = CollectionManagementService.Utils.nameToPath("at.redlink:test:1.0.0");
-        assertEquals(path, "at/redlink/test/1.0.0/test-1.0.0.jar");
+        assertEquals(Paths.get("at/redlink/test/1.0.0/test-1.0.0.jar"), Paths.get(path));
+    }
+
+    @Test
+    public void utilsNameToUrlPathTest() throws IOException {
+        String path = CollectionManagementService.Utils.nameToUrlPath("at.redlink:test:1.0.0");
+        assertEquals("at/redlink/test/1.0.0/test-1.0.0.jar", path);
     }
 
     @Test(expected = IOException.class)
@@ -55,6 +60,6 @@ public class CollectionManagementServiceUtilsTest {
     @Test
     public void testDownloadConfiguration() throws IOException {
         Path configDir = service.downloadConfiguration("com.rbmhtechnology.vind:backend-solr:1.2.2");
-        assertTrue(configDir.toString().endsWith("/unzipped/solrhome/core/conf"));
+        assertTrue(configDir.toString().endsWith(Paths.get("/unzipped/solrhome/core/conf").toString()));
     }
 }


### PR DESCRIPTION
There was another part of the code incompatible with Windows systems.

Since urls and paths differ in spelling I created another method to derive the url from the configName.

I also fixed the tests so they succeed in a Windows environment.