### PR TITLE
#102: deleting nested docs directly with block join query

### DIFF
--- a/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
+++ b/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
@@ -857,7 +857,11 @@ public class SolrSearchServer extends SearchServer {
         try {
             solrClientLogger.debug(">>> delete query({})", query);
 
-            final UpdateResponse deleteChildrenResponse = solrClient.deleteByQuery(String.format("{!child of=\"_type_:%s\" v='%s'}",factory.getType(), query.trim().replaceAll("^\\+","")));
+            final UpdateResponse deleteChildrenResponse =
+                    solrClient.deleteByQuery(
+                            String.format("{!child of='_type_:%s' v='%s'}",
+                                    factory.getType(),
+                                    query.trim().replaceAll("^\\+","").replaceAll("'","\"")));
             long qTime = deleteChildrenResponse.getQTime();
             long elapsedTime = deleteChildrenResponse.getElapsedTime();
             final UpdateResponse deleteResponse = solrClient.deleteByQuery(query.trim().replaceAll("^\\+",""));

--- a/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
+++ b/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
@@ -856,24 +856,13 @@ public class SolrSearchServer extends SearchServer {
         String query = SolrUtils.Query.buildFilterString(delete.getQuery(), factory, delete.getUpdateContext(),true);
         try {
             solrClientLogger.debug(">>> delete query({})", query);
-            //Finding the ID of the documents to delete
-            final SolrQuery solrQuery = new SolrQuery();
-            solrQuery.setParam(CommonParams.Q, "*:*");
-            solrQuery.setParam(CommonParams.FQ,query.trim().replaceAll("^\\+","").split("\\+"));
-            final QueryResponse response = solrClient.query(solrQuery, REQUEST_METHOD);
-            long qTime = 0;
-            long elapsedTime = 0;
-            if(Objects.nonNull(response) && CollectionUtils.isNotEmpty(response.getResults())){
-                final List<String> idList = response.getResults().stream().map(doc -> (String) doc.get(ID)).collect(Collectors.toList());
-                final UpdateResponse deleteResponse = solrClient.deleteById(idList);
-                qTime = deleteResponse.getQTime();
-                elapsedTime = deleteResponse.getElapsedTime();
-                //Deleting nested documents
-                final UpdateResponse deleteNestedResponse = solrClient.deleteByQuery("_root_:(" + StringUtils.join(idList, " OR ") + ")");
 
-                qTime += deleteNestedResponse.getQTime();
-                elapsedTime += deleteNestedResponse.getElapsedTime();
-            }
+            final UpdateResponse deleteChildrenResponse = solrClient.deleteByQuery(String.format("{!child of=\"_type_:%s\" v='%s'}",factory.getType(), query.trim().replaceAll("^\\+","")));
+            long qTime = deleteChildrenResponse.getQTime();
+            long elapsedTime = deleteChildrenResponse.getElapsedTime();
+            final UpdateResponse deleteResponse = solrClient.deleteByQuery(query.trim().replaceAll("^\\+",""));
+            qTime += deleteResponse.getQTime();
+            elapsedTime += deleteResponse.getElapsedTime();
 
             return new DeleteResult(qTime).setElapsedTime(elapsedTime);
         } catch (SolrServerException | IOException e) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -136,3 +136,7 @@ default scope due to a null FieldDescriptor.
 
 #2.2.1
 * Fix: alignment of language specific fields tokenizer with generic text definition
+
+# 2.3.0
+* Improvement: Delete by query no longer queries for the ids of the documents as it was not performing for long sets of 
+documents matching the delete filters.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.rbmhtechnology.vind</groupId>
     <artifactId>vind</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vind</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.rbmhtechnology.vind</groupId>
     <artifactId>vind</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.2.1</version>
     <packaging>pom</packaging>
 
     <name>Vind</name>


### PR DESCRIPTION
Remove id query and added a first deletion by query to remove the children of those documents matching the deletion query.