### PR TITLE
#204: limit suggestions based on an existing fulltext search

### DIFF
--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/FulltextTerm.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/FulltextTerm.java
@@ -1,0 +1,23 @@
+package com.rbmhtechnology.vind.api.query;
+
+public class FulltextTerm {
+  private final String fulltextSearchTerm;
+  private final String minimumMatch;
+
+  public FulltextTerm(String fulltextSearchTerm, String minimumMatch) {
+    this.fulltextSearchTerm = fulltextSearchTerm;
+    this.minimumMatch = minimumMatch;
+  }
+
+  public String getFulltextSearchTerm() {
+    return fulltextSearchTerm;
+  }
+
+  public String getMinimumMatch() {
+    return minimumMatch;
+  }
+
+  public FulltextTerm copy() {
+    return new FulltextTerm(getFulltextSearchTerm(), getMinimumMatch());
+  }
+}

--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/DescriptorSuggestionSearch.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/DescriptorSuggestionSearch.java
@@ -1,12 +1,17 @@
 package com.rbmhtechnology.vind.api.query.suggestion;
 
+import com.rbmhtechnology.vind.api.query.FulltextSearch;
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.filter.Filter;
 import com.rbmhtechnology.vind.model.FieldDescriptor;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+
+import static java.util.Optional.empty;
 
 /**
  * Class to configure suggestions based on field descriptors.
@@ -21,6 +26,8 @@ public class DescriptorSuggestionSearch implements ExecutableSuggestionSearch {
     private Filter filter = null;
     private Set<FieldDescriptor> suggestionFields = new HashSet<>();
     private String searchContext = null;
+    private Optional<FulltextTerm> fulltextTerm = empty();
+
     /**
      * Creates a new instance of {@link DescriptorSuggestionSearch}.
      * @param input String text to find suggestion for.
@@ -28,14 +35,14 @@ public class DescriptorSuggestionSearch implements ExecutableSuggestionSearch {
      * @param field {@link FieldDescriptor} fields where to find the suggestions.
      */
     protected DescriptorSuggestionSearch(String input, int limit, Filter filter, FieldDescriptor ... field) {
-        Objects.requireNonNull(field);
-        this.input = input;
-        this.limit = limit;
-        this.filter = filter;
-        suggestionFields.addAll(Arrays.asList(field));
+      Objects.requireNonNull(field);
+      this.input = input;
+      this.limit = limit;
+      this.filter = filter;
+      suggestionFields.addAll(Arrays.asList(field));
     }
 
-    /**
+  /**
      * Set the text to find suggestions for.
      * @param input String text to find suggestion for.
      * @return {@link DescriptorSuggestionSearch} with the new text.
@@ -161,5 +168,14 @@ public class DescriptorSuggestionSearch implements ExecutableSuggestionSearch {
     @Override
     public boolean isStringSuggestion() {
         return false;
+    }
+
+    public Optional<FulltextTerm> getFulltextTerm() {
+        return fulltextTerm;
+    }
+
+    public DescriptorSuggestionSearch fulltextTerm(final FulltextTerm fulltextTerm) {
+        this.fulltextTerm = Optional.ofNullable(fulltextTerm);
+        return this;
     }
 }

--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/ExecutableSuggestionSearch.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/ExecutableSuggestionSearch.java
@@ -1,6 +1,9 @@
 package com.rbmhtechnology.vind.api.query.suggestion;
 
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.filter.Filter;
+
+import java.util.Optional;
 
 /**
  * @author Thomas Kurz (tkurz@apache.org)
@@ -22,6 +25,10 @@ public interface ExecutableSuggestionSearch {
     public ExecutableSuggestionSearch setLimit(int limit);
 
     public ExecutableSuggestionSearch context(String context);
+
+    public Optional<FulltextTerm> getFulltextTerm();
+
+    public ExecutableSuggestionSearch fulltextTerm(FulltextTerm fulltextTerm);
 
     public int getLimit();
 

--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/StringSuggestionSearch.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/StringSuggestionSearch.java
@@ -1,11 +1,15 @@
 package com.rbmhtechnology.vind.api.query.suggestion;
 
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.filter.Filter;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+
+import static java.util.Optional.empty;
 
 /**
  * Class to configure suggestions based on field String names.
@@ -20,6 +24,7 @@ public class StringSuggestionSearch implements ExecutableSuggestionSearch {
     private Filter filter = null;
     private Set<String> suggestionFields = new HashSet<>();
     private String searchContext = null;
+    private Optional<FulltextTerm> fulltextTerm = empty();
 
     /**
      * Creates a new instance of {@link StringSuggestionSearch}.
@@ -58,6 +63,17 @@ public class StringSuggestionSearch implements ExecutableSuggestionSearch {
     @Override
     public StringSuggestionSearch context(String context) {
         this.searchContext = context;
+        return this;
+    }
+
+    @Override
+    public Optional<FulltextTerm> getFulltextTerm() {
+        return fulltextTerm;
+    }
+
+    @Override
+    public StringSuggestionSearch fulltextTerm(final FulltextTerm fulltextTerm) {
+        this.fulltextTerm = Optional.ofNullable(fulltextTerm);
         return this;
     }
 

--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/SuggestionSearch.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/suggestion/SuggestionSearch.java
@@ -1,12 +1,17 @@
 package com.rbmhtechnology.vind.api.query.suggestion;
 
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.filter.Filter;
+import com.rbmhtechnology.vind.model.DocumentFactoryBuilder;
 import com.rbmhtechnology.vind.model.FieldDescriptor;
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.util.Optional.empty;
 
 /**
  * Class to prepare suggestion queries.
@@ -19,6 +24,7 @@ public class SuggestionSearch {
     private Set<FieldDescriptor> suggestionFields = new HashSet<>();
     private Set<String> suggestionStringFields = new HashSet<>();
     private String searchContext = null;
+    private Optional<FulltextTerm> fulltextTerm = empty();
 
     /**
      * Creates a new instance of {@link SuggestionSearch}.
@@ -42,6 +48,7 @@ public class SuggestionSearch {
         copy.suggestionFields = this.suggestionFields;
         copy.suggestionStringFields = this.suggestionStringFields;
         copy.searchContext = this.searchContext;
+        copy.fulltextTerm = this.fulltextTerm;
         return copy;
     }
 
@@ -123,7 +130,7 @@ public class SuggestionSearch {
      */
     //FIXME: this supports also: fields()
     public StringSuggestionSearch fields(String... fields) {
-        return new StringSuggestionSearch(input,limit,filter,fields).context(this.searchContext);
+        return new StringSuggestionSearch(input,limit,filter,fields).context(this.searchContext).fulltextTerm(fulltextTerm.orElse(null));
     }
 
     /**
@@ -132,7 +139,7 @@ public class SuggestionSearch {
      * @return {@link DescriptorSuggestionSearch} with the added field.
      */
     public DescriptorSuggestionSearch addField(FieldDescriptor field) {
-        return new DescriptorSuggestionSearch(input,limit,filter,field).context(this.searchContext);
+        return new DescriptorSuggestionSearch(input,limit,filter,field).context(this.searchContext).fulltextTerm(fulltextTerm.orElse(null));
     }
     /**
      * Adds the fields to search for suggestions in.
@@ -141,7 +148,7 @@ public class SuggestionSearch {
      */
     //FIXME: this supports also: fields()
     public DescriptorSuggestionSearch fields(FieldDescriptor... fields) {
-        return new DescriptorSuggestionSearch(input,limit,filter,fields).context(this.searchContext);
+        return new DescriptorSuggestionSearch(input,limit,filter,fields).context(this.searchContext).fulltextTerm(fulltextTerm.orElse(null));
     }
 
     /**
@@ -177,4 +184,18 @@ public class SuggestionSearch {
         return this.searchContext;
     }
 
+    /**
+     * Get the fulltext term, to base the search on.
+     * Useful when suggesting within an already existing fulltext search
+     *
+     * @return a fulltext term
+     */
+    public Optional<FulltextTerm> getFulltextTerm() {
+        return fulltextTerm;
+    }
+
+    public SuggestionSearch fulltextTerm(final FulltextTerm fulltextTerm) {
+        this.fulltextTerm = Optional.ofNullable(fulltextTerm);
+        return this;
+    }
 }

--- a/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/util/ElasticQueryBuilder.java
+++ b/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/util/ElasticQueryBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.rbmhtechnology.vind.SearchServerException;
 import com.rbmhtechnology.vind.api.query.FulltextSearch;
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.datemath.DateMathExpression;
 import com.rbmhtechnology.vind.api.query.division.Cursor;
 import com.rbmhtechnology.vind.api.query.division.Page;
@@ -52,7 +53,6 @@ import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBui
 import org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
-import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.SuggestBuilder;
@@ -153,26 +153,7 @@ public class ElasticQueryBuilder {
             searchString = skipColonSearchString;
         }
 
-        String minimumShouldMatch = search.getMinimumShouldMatch();
-        if(StringUtils.isNumeric(minimumShouldMatch) && !minimumShouldMatch.startsWith("-")) {
-            minimumShouldMatch = "0<" + minimumShouldMatch;
-        }
-        final QueryStringQueryBuilder fullTextStringQuery = QueryBuilders.queryStringQuery(searchString)
-                .minimumShouldMatch(minimumShouldMatch); //mm
-        // Set fulltext fields
-        factory.getFields().values().stream()
-                .filter( FieldDescriptor::isFullText)
-                .map( field -> Pair.of(FieldUtil.getFieldName(field, UseCase.Fulltext, searchContext, indexFootPrint), field.getBoost()))
-                .filter( pair -> pair.getKey().isPresent())
-                .forEach( field -> fullTextStringQuery
-                        .field(field.getKey().get(),field.getValue()));
-
-        if(fullTextStringQuery.fields().isEmpty()) {
-            fullTextStringQuery.defaultField("full_text");
-        }
-
-        final DisMaxQueryBuilder query = QueryBuilders.disMaxQuery()
-                .add(fullTextStringQuery);
+        final DisMaxQueryBuilder query = createDisMaxQueryBuilder(new FulltextTerm(searchString, search.getMinimumShouldMatch()), factory, indexFootPrint, searchContext);
 
         baseQuery.must(query);
         searchSource.query(baseQuery);
@@ -316,6 +297,29 @@ public class ElasticQueryBuilder {
         return searchSource;
     }
 
+    private static DisMaxQueryBuilder createDisMaxQueryBuilder(FulltextTerm fulltextTerm, DocumentFactory factory, List<String> indexFootPrint, String searchContext) {
+        String minimumShouldMatch = fulltextTerm.getMinimumMatch();
+        if(StringUtils.isNumeric(minimumShouldMatch) && !minimumShouldMatch.startsWith("-")) {
+            minimumShouldMatch = "0<" + minimumShouldMatch;
+        }
+        final QueryStringQueryBuilder fullTextStringQuery = QueryBuilders.queryStringQuery(fulltextTerm.getFulltextSearchTerm())
+                .minimumShouldMatch(minimumShouldMatch); //mm
+        // Set fulltext fields
+        factory.getFields().values().stream()
+                .filter( FieldDescriptor::isFullText)
+                .map( field -> Pair.of(FieldUtil.getFieldName(field, UseCase.Fulltext, searchContext, indexFootPrint), field.getBoost()))
+                .filter( pair -> pair.getKey().isPresent())
+                .forEach( field -> fullTextStringQuery
+                        .field(field.getKey().get(),field.getValue()));
+
+        if(fullTextStringQuery.fields().isEmpty()) {
+            fullTextStringQuery.defaultField("full_text");
+        }
+
+        return QueryBuilders.disMaxQuery()
+          .add(fullTextStringQuery);
+    }
+
     public static SearchSourceBuilder buildPercolatorQueryReadiness(DocumentFactory factory) {
 
         final SearchSourceBuilder searchSource = new SearchSourceBuilder();
@@ -382,14 +386,14 @@ public class ElasticQueryBuilder {
             case "TermsQueryFilter":
                 final Filter.TermsQueryFilter termsQueryFilter = (Filter.TermsQueryFilter) filter;
 
-                final Optional<String> termsQueryFilterFieldName = 
+                final Optional<String> termsQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(termsQueryFilter.getField()), useCase,context, indexFootPrint);
                 return termsQueryFilterFieldName.map(s -> QueryBuilders
                         .termsQuery(s, termsQueryFilter.getTerm())).orElse(null);
 
             case "PrefixFilter":
                 final Filter.PrefixFilter prefixFilter = (Filter.PrefixFilter) filter;
-                final Optional<String> prefixQueryFilterFieldName = 
+                final Optional<String> prefixQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(prefixFilter.getField()), useCase,context, indexFootPrint)
                 ;
                 return prefixQueryFilterFieldName.map(s -> QueryBuilders
@@ -397,7 +401,7 @@ public class ElasticQueryBuilder {
 
             case "DescriptorFilter":
                 final Filter.DescriptorFilter descriptorFilter = (Filter.DescriptorFilter) filter;
-                final Optional<String> descriptorQueryFilterFieldName = 
+                final Optional<String> descriptorQueryFilterFieldName =
                         FieldUtil.getFieldName(descriptorFilter.getDescriptor(), useCase, context, indexFootPrint)
                 ;
                 return descriptorQueryFilterFieldName.map(s -> QueryBuilders
@@ -405,7 +409,7 @@ public class ElasticQueryBuilder {
 
             case "BetweenDatesFilter":
                 final Filter.BetweenDatesFilter betweenDatesFilter = (Filter.BetweenDatesFilter) filter;
-                final Optional<String> betweenDatesQueryFilterFieldName = 
+                final Optional<String> betweenDatesQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(betweenDatesFilter.getField()), useCase,context, indexFootPrint)
                 ;
                 return betweenDatesQueryFilterFieldName.map(s -> QueryBuilders
@@ -416,7 +420,7 @@ public class ElasticQueryBuilder {
 
             case "BeforeFilter":
                 final Filter.BeforeFilter beforeFilter = (Filter.BeforeFilter) filter;
-                final Optional<String> beforeQueryFilterFieldName = 
+                final Optional<String> beforeQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(beforeFilter.getField()), useCase,context, indexFootPrint)
                 ;
                 return beforeQueryFilterFieldName.map(s -> QueryBuilders
@@ -426,7 +430,7 @@ public class ElasticQueryBuilder {
 
             case "AfterFilter":
                 final Filter.AfterFilter afterFilter = (Filter.AfterFilter) filter;
-                final Optional<String> afterQueryFilterFieldName = 
+                final Optional<String> afterQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(afterFilter.getField()), useCase,context, indexFootPrint)
                 ;
                 return afterQueryFilterFieldName.map(s -> QueryBuilders
@@ -436,7 +440,7 @@ public class ElasticQueryBuilder {
 
             case "BetweenNumericFilter":
                 final Filter.BetweenNumericFilter betweenNumericFilter = (Filter.BetweenNumericFilter) filter;
-                final Optional<String> betweenNumericQueryFilterFieldName = 
+                final Optional<String> betweenNumericQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(betweenNumericFilter.getField()), useCase, context, indexFootPrint);
                 return betweenNumericQueryFilterFieldName.map(s -> QueryBuilders
                         .rangeQuery(betweenNumericQueryFilterFieldName.get())
@@ -445,7 +449,7 @@ public class ElasticQueryBuilder {
                         .orElse(null);
             case "LowerThanFilter":
                 final Filter.LowerThanFilter lowerThanFilter = (Filter.LowerThanFilter) filter;
-                final Optional<String> lowerThanQueryFilterFieldName = 
+                final Optional<String> lowerThanQueryFilterFieldName =
                         FieldUtil.getFieldName(factory.getField(lowerThanFilter.getField()), useCase, context, indexFootPrint);
                 return lowerThanQueryFilterFieldName.map(s -> QueryBuilders
                         .rangeQuery(lowerThanQueryFilterFieldName.get())
@@ -1197,6 +1201,11 @@ public class ElasticQueryBuilder {
                         .addSuggestion(
                                 FieldUtil.getSourceFieldName(fieldName.replaceAll("\\.suggestion", ""), searchContext),
                                 SuggestBuilders.termSuggestion(fieldName.concat("_experimental")).prefixLength(0)));
+
+        search.getFulltextTerm().ifPresent(fulltextTerm -> {
+            QueryBuilder query = createDisMaxQueryBuilder(fulltextTerm, factory, indexFootPrint, searchContext);
+            searchSource.query(query);
+        });
 
         searchSource.suggest(suggestBuilder);
         return searchSource;

--- a/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
+++ b/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
@@ -1035,6 +1035,8 @@ public class SolrSearchServer extends SmartSearchServerBase {
 
         query.add(CommonParams.FQ, parentTypeFilter);
 
+        search.getFulltextTerm().ifPresent(fulltextTerm -> query.add(CommonParams.FQ, fulltextTerm.getFulltextSearchTerm()));
+
         //filters
         if(search.hasFilter()) {
             SolrUtils.Query.buildFilterString(search.getFilter(), assets,childFactory,query, searchContext, false);

--- a/pom.xml
+++ b/pom.xml
@@ -580,12 +580,12 @@
     <profiles>
         <profile>
             <id>elastic</id>
-        </profile>
-        <profile>
-            <id>solr</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+        </profile>
+        <profile>
+            <id>solr</id>
         </profile>
         <profile>
             <id>quick</id>

--- a/test/src/test/java/com/rbmhtechnology/vind/test/SuggestionSearchIT.java
+++ b/test/src/test/java/com/rbmhtechnology/vind/test/SuggestionSearchIT.java
@@ -4,6 +4,7 @@
 package com.rbmhtechnology.vind.test;
 
 import com.rbmhtechnology.vind.api.SearchServer;
+import com.rbmhtechnology.vind.api.query.FulltextTerm;
 import com.rbmhtechnology.vind.api.query.Search;
 import com.rbmhtechnology.vind.api.query.filter.Filter;
 import com.rbmhtechnology.vind.api.result.SearchResult;
@@ -16,6 +17,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static com.rbmhtechnology.vind.api.query.filter.Filter.eq;
 import static com.rbmhtechnology.vind.test.Backend.Elastic;
@@ -185,6 +188,7 @@ public class SuggestionSearchIT {
         server.delete(parent.createDoc("P_SPEC_CHAR"));
         server.commit();
     }
+
     @Test
     @RunWithBackend({Solr, Elastic})
     public void testMultiWordSuggestion() {
@@ -202,6 +206,26 @@ public class SuggestionSearchIT {
 
         Assert.assertEquals(3, suggestionResult.size());
 
+    }
+
+    @Test
+    @RunWithBackend({Solr, Elastic})
+    public void testMultiWordSuggestionWithBaseSearchTerm() {
+
+        server.index(
+                parent.createDoc("multi1").setValue(parent_value, "León city"));
+        server.index(
+                parent.createDoc("multi2").setValue(parent_value, "Lerida"));
+        server.index(
+                parent.createDoc("multi3").setValue(parent_value, "Oviedo city"));
+        server.index(
+                parent.createDoc("multi4").setValue(parent_value, "Oviñana"));
+        server.commit();
+
+        SuggestionResult suggestionResult = server.execute(Search.suggest("Ov").fulltextTerm(new FulltextTerm("city", "100%")).addField(parent_value), parent);
+
+        Assert.assertEquals(1, suggestionResult.size());
+        assertEquals("Oviedo city", suggestionResult.get(parent_value).getValues().get(0).getValue());
     }
 
     @Test


### PR DESCRIPTION
Suggestions for specific fields can be limited by filters, so the suggestions only show values, that are available in an existing search.
This PR adds the ability to also limit by an existing fulltext search, for suggestion results, that better match an existing search result.

To achieve this suggestion searches may now receive an optional fulltext term.

Example:
```java
Search.suggest("JF")
  .fulltextTerm(Optional.of(new FulltextTerm("New York", "100%")))
  .fields(airportCodeFieldDescriptor)
```