### PR TITLE
Escape lucene based special characters when flag is set

### DIFF
--- a/api/src/main/java/com/rbmhtechnology/vind/api/query/FulltextSearch.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/api/query/FulltextSearch.java
@@ -48,6 +48,7 @@ public class FulltextSearch {
     private boolean strict = true;
     private boolean spellcheck = false;
     private boolean smartParsing = false;
+    private boolean escapeCharacter = false;
 
     /**
      * Creates a new basic full text search query object.
@@ -74,6 +75,10 @@ public class FulltextSearch {
 
         this.getFacets().keySet().stream().forEach(k -> copy.facets.put(k,this.getFacets().get(k).clone()));
         copy.setFacetLimit(this.getFacetLimit());
+        copy.setStrict(this.strict);
+        copy.spellcheck(this.spellcheck);
+        copy.smartParsing(this.smartParsing);
+        copy.escapeCharacter(this.escapeCharacter);
         return copy;
     }
 
@@ -682,6 +687,15 @@ public class FulltextSearch {
         return this;
     }
 
+    public boolean isEscapeCharacter() {
+        return escapeCharacter;
+    }
+
+    public FulltextSearch escapeCharacter(boolean escapeCharacter) {
+        this.escapeCharacter = escapeCharacter;
+        return this;
+    }
+
     @Override
     public String toString(){
         String searchString = "" +
@@ -703,6 +717,7 @@ public class FulltextSearch {
                 "\"searchContext\":\"%s\"," +
                 "\"strictFlag\":%s" +
                 "\"smartParsing\":%s" +
+                "\"escapeCharacter\":%s" +
                 "}";
 
         return String.format(searchString,
@@ -722,7 +737,8 @@ public class FulltextSearch {
                 this.geoDistance,
                 this.searchContext,
                 this.strict,
-                this.isSmartParsing()
+                this.isSmartParsing(),
+                this.escapeCharacter
         );
     }
 

--- a/api/src/main/java/com/rbmhtechnology/vind/utils/SpecialCharacterEscaping.java
+++ b/api/src/main/java/com/rbmhtechnology/vind/utils/SpecialCharacterEscaping.java
@@ -1,0 +1,40 @@
+package com.rbmhtechnology.vind.utils;
+
+public class SpecialCharacterEscaping {
+
+    public static final String[] RESERVED_CHARACTERS = new String[] {
+        "\\", // having this at the beginning is important to not escape \ which are used for escaping the following characters
+        "+",
+        "-",
+        "=",
+        "&",
+        "|",
+        "!",
+        "(",
+        ")",
+        "{",
+        "}",
+        "[",
+        "]",
+        "^",
+        "\"",
+        "~",
+        "*",
+        "?",
+        ":",
+        "/",
+        "<",
+        ">",
+    };
+
+    private SpecialCharacterEscaping() {
+    }
+
+    public static String escapeSpecialCharacters(final String input) {
+        String intermediateEscaping = input;
+        for (String reservedCharacter : RESERVED_CHARACTERS) {
+            intermediateEscaping = intermediateEscaping.replace(reservedCharacter, "\\"+reservedCharacter);
+        }
+        return intermediateEscaping;
+    }
+}

--- a/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/ElasticSearchServer.java
+++ b/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/ElasticSearchServer.java
@@ -84,8 +84,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.rbmhtechnology.vind.api.query.division.ResultSubset.DivisionType.cursor;
-import static com.rbmhtechnology.vind.elasticsearch.backend.util.CursorUtils.toSearchAfterCursor;
 import static com.rbmhtechnology.vind.elasticsearch.backend.util.DocumentUtil.createEmptyDocument;
+import static com.rbmhtechnology.vind.utils.SpecialCharacterEscaping.escapeSpecialCharacters;
 
 public class ElasticSearchServer extends SmartSearchServerBase {
 
@@ -346,7 +346,9 @@ public class ElasticSearchServer extends SmartSearchServerBase {
 
         //query
         try {
-            final String searchString = search.getSearchString();
+            final String searchString = search.isEscapeCharacter()
+                    ? escapeSpecialCharacters(search.getSearchString())
+                    : search.getSearchString();
             final ValidateQueryResponse validateQueryResponse = elasticSearchClient.validateQuery(searchString);
             if (validateQueryResponse.isValid()) {
                 search.text(searchString);

--- a/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/util/ElasticQueryBuilder.java
+++ b/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/util/ElasticQueryBuilder.java
@@ -52,7 +52,6 @@ import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBui
 import org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
-import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.SuggestBuilder;

--- a/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
+++ b/backend/solr/src/main/java/com/rbmhtechnology/vind/solr/backend/SolrSearchServer.java
@@ -38,6 +38,7 @@ import com.rbmhtechnology.vind.model.DocumentFactory;
 import com.rbmhtechnology.vind.model.FieldDescriptor;
 import com.rbmhtechnology.vind.model.InverseSearchQuery;
 import com.rbmhtechnology.vind.model.value.LatLng;
+import com.rbmhtechnology.vind.utils.SpecialCharacterEscaping;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
@@ -94,6 +95,7 @@ import static com.rbmhtechnology.vind.solr.backend.SolrUtils.Fieldname.ID;
 import static com.rbmhtechnology.vind.solr.backend.SolrUtils.Fieldname.TEXT;
 import static com.rbmhtechnology.vind.solr.backend.SolrUtils.Fieldname.TYPE;
 import static com.rbmhtechnology.vind.solr.backend.SolrUtils.Fieldname.getFieldname;
+import static com.rbmhtechnology.vind.utils.SpecialCharacterEscaping.escapeSpecialCharacters;
 
 /**
  * @author Thomas Kurz (tkurz@apache.org)
@@ -467,7 +469,10 @@ public class SolrSearchServer extends SmartSearchServerBase {
         }
 
         // fulltext search
-        query.set(CommonParams.Q, search.getSearchString());
+        query.set(
+            CommonParams.Q,
+            search.isEscapeCharacter() ? escapeSpecialCharacters(search.getSearchString()) : search.getSearchString()
+        );
 
         if(SearchConfiguration.get(SearchConfiguration.SEARCH_RESULT_SHOW_SCORE, true)) {
             query.set(CommonParams.FL, "*,score");


### PR DESCRIPTION
This PR will enable to automatically escape for special characters to search for values which uses one of them.
However this kind of is already implemented in [ElasticQueryBuilder](https://github.com/RBMHTechnology/vind/blob/8147a5ebdbb4116b212e3b7b91ba03c0b04df8c3/backend/elasticsearch/src/main/java/com/rbmhtechnology/vind/elasticsearch/backend/util/ElasticQueryBuilder.java#L89), but that implementation escapes differently and only in ElasticSearch.

In our application we did not use the `SearchSourceBuilder` to set up queries and it would take much effort to rewrite the queries to allow escaping.

Closes #201